### PR TITLE
Make bot aware of its own username

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -84,7 +84,7 @@ function replyText(text, message) {
   bot.sendMessage(message.chat.id, text, {'reply_to_message_id': message.message_id});
 }
 
-bot.on('message', function(message) {
+function handleMessage(message) {
   if (message.new_chat_participant) {
     replyText(getInsult(message, message.new_chat_participant), message);
   } else if (message.text) {
@@ -99,4 +99,8 @@ bot.on('message', function(message) {
   } else if (Math.random() * 30 < 1) {
     replyText(getInsult(message, message.from), message);
   }
+}
+
+bot.on('message', function(message) {
+  handleMessage(message);
 });

--- a/bot.js
+++ b/bot.js
@@ -75,6 +75,11 @@ function getInsult(message, user) {
   return insults[Math.floor(Math.random() * insults.length)];
 }
 
+var bot_name = undefined;
+bot.getMe().done(function(res){
+  bot_name = res.username;
+});
+
 /**
  * Replies to a message
  * @param {string} text - The text to send
@@ -85,6 +90,12 @@ function replyText(text, message) {
 }
 
 function handleMessage(message) {
+  if (bot_name===undefined) {
+    setTimeout(function(){
+      handleMessage(message);
+    }, 3000);
+    return;
+  }
   if (message.new_chat_participant) {
     replyText(getInsult(message, message.new_chat_participant), message);
   } else if (message.text) {
@@ -93,7 +104,7 @@ function handleMessage(message) {
       replyText(monkey_island_match, message);
     } else if (/mue?tt?(er|i)/i.test(message.text)) {
       replyText('HANI MUETTER GHÖRT??!', message);
-    } else if (/CoredumpFlameBot/.test(message.text) || Math.random() * 30 < 1) {
+    } else if (RegExp(bot_name).test(message.text) || Math.random() * 30 < 1) {
       replyText(getInsult(message, message.from), message);
     }
   } else if (Math.random() * 30 < 1) {


### PR DESCRIPTION
Currently the user name is hard coded in the [source](https://github.com/coredump-ch/telegram-flame-bot/blob/ae6f6dca83222d7a99e00c62d6ddb31bddbd6561/bot.js#L96).

It would be possible to get the bot user name with [getMe](https://github.com/yagop/node-telegram-bot-api#TelegramBot+getMe).
