### PR TITLE
Log start-of-process

### DIFF
--- a/src/FlameBot.ts
+++ b/src/FlameBot.ts
@@ -34,6 +34,7 @@ export class FlameBot {
    * Sets the handler to listen to messages
    */
   public start() {
+    console.info('Starting telegram-flame-bot...');
     this.telegram.on('message', (message: TelegramBot.Message) => {
       this.handleMessage(message);
     });

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
         "interface-name": [true, "never-prefix"],
         "max-classes-per-file": false,
         "member-ordering": false,
+        "no-console": [true, "log"],
         "no-namespace": [true, "allow-declarations"],
         "object-literal-shorthand": false,
         "object-literal-sort-keys": false,


### PR DESCRIPTION
Fixes #30.

I'm not 100% sure if `console.log` is the correct way to do things.